### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ composer require runtime/roadrunner-symfony-nyholm
 Define the environment variable `APP_RUNTIME` for your application.
 
 ```
-APP_RUNTIME=Runtime\RoadRunnerSymfonyNyholm\Runtime
+APP_RUNTIME=Runtime\\RoadRunnerSymfonyNyholm\\Runtime
 ```
 
 


### PR DESCRIPTION
docs: Improving the usage example. In order to keep the backslash we need double backslash. Learned the hard way by blindly copy pasting to .env :(